### PR TITLE
Parameter syntax fix

### DIFF
--- a/install_new_adds_forest.ps1
+++ b/install_new_adds_forest.ps1
@@ -25,9 +25,9 @@
 
     [CmdletBinding()]
 param (
-    [Parameter(Mandatory=$true)][string]$DomainName,
-    [Parameter(Mandatory=$true)][string]$DomainNetBiosName,
-    [Parameter(Mandatory=$true)][String]$DSRMPassword
+    [Parameter(Mandatory)][string]$DomainName,
+    [Parameter(Mandatory)][string]$DomainNetBiosName,
+    [Parameter(Mandatory)][string]$DSRMPassword
 )
 
 # Install AD DS feature


### PR DESCRIPTION
Setting the parameter mandatory is by default 'true', so there is no need to specify value additionaly.